### PR TITLE
Patch Salesforce module to log all httpRequest() calls

### DIFF
--- a/patches/salesforce-watchdog--all-http-requests.patch
+++ b/patches/salesforce-watchdog--all-http-requests.patch
@@ -1,0 +1,17 @@
+diff --git a/includes/salesforce.inc b/includes/salesforce.inc
+index 6cda48e..30edbed 100644
+--- a/includes/salesforce.inc
++++ b/includes/salesforce.inc
+@@ -153,6 +153,12 @@ class Salesforce {
+       'data' => $data,
+     );
+ 
++    // Log this httpRequest.
++    watchdog('salesforce', 'httpRequest: @url, $options: @options', array(
++      '@url' => $url,
++      '@options' => print_r($options, TRUE)
++      ), WATCHDOG_DEBUG);
++
+     return drupal_http_request($url, $options);
+   }
+ 

--- a/springboard-core.make
+++ b/springboard-core.make
@@ -162,6 +162,9 @@ projects[salesforce][patch][1934790] = http://drupal.org/files/salesforce-sandox
 ; Additional caching login in describObject method
 projects[salesforce][patch][2037609] = http://drupal.org/files/salesforce-object-additional-caching.patch
 
+; Additional logging for Salesforce API calls
+projects[salesforce][patch][] = https://raw.github.com/JacksonRiver/Springboard-Build/7.x-4.x-sf-api-logging/patches/salesforce-watchdog--all-http-requests.patch
+
 ; Make encrypt module use the encrypt key
 projects[encrypt][patch][1927572] = http://drupal.org/files/encrypt_key_is_never_used.patch
 


### PR DESCRIPTION
This adds a patch to the Salesforce module (specifically, `includes/salesforce.inc`) that sends all `httpRequest()` calls to `watchdog()` as a debug item. It includes the entire URL and `$options` array.