### PR TITLE
Updated webform_ab to version 2.3 in makefile

### DIFF
--- a/springboard-core.make
+++ b/springboard-core.make
@@ -172,7 +172,7 @@ projects[webform][subdir] = contrib
 projects[webform][version] = 3.20
 
 projects[webform_ab][subdir] = contrib
-projects[webform_ab][version] = 2.1
+projects[webform_ab][version] = 2.3
 
 projects[services][subdir] = contrib
 projects[services][version] = 3.7


### PR DESCRIPTION
There was a bug in Webform_AB module, which caused the cron search indexer to crash when it came upon a Webform A/B Test node. David Barbarisi found the bug and I committed it to D.O. Version 2.3 is the newly-rolled version and this updates the Springboard makefiles accordingly.