### PR TITLE
Update Views to version 3.10

### DIFF
--- a/springboard-core.make
+++ b/springboard-core.make
@@ -157,7 +157,7 @@ projects[video_embed_field][subdir] = contrib
 projects[video_embed_field][version] = 2.0-beta7
 
 projects[views][subdir] = contrib
-projects[views][version] = 3.7
+projects[views][version] = 3.10
 
 projects[views_bulk_operations][subdir] = contrib
 projects[views_bulk_operations][version] = 3.1


### PR DESCRIPTION
Previous version is 3.7 so it's a decent size code change.

To test I ran the automated simpletests and acceptance tests before and after the update and they passed both times. To be fair, there isn't much in the tests that would fail due to Views.

