### PR TITLE
7.x 4.x silverpop transact

### DIFF
--- a/springboard-core.make
+++ b/springboard-core.make
@@ -181,6 +181,9 @@ projects[securepages][version] = 1.0-beta1
 projects[shorten][subdir] = contrib
 projects[shorten][version] = 1.2
 
+projects[smtp][subdir] = contrib
+projects[smtp][version] = 1.3
+
 projects[strongarm][subdir] = contrib
 projects[strongarm][version] = 2.0
 

--- a/springboard-core.make
+++ b/springboard-core.make
@@ -26,7 +26,7 @@ projects[springboard_themes][download][branch] = 7.x-4.x
 projects[springboard][type] = module
 projects[springboard][download][type] = git
 projects[springboard][download][url] = git://github.com/JacksonRiver/springboard_modules.git
-projects[springboard][download][branch] = 7.x-4.x
+projects[springboard][download][branch] = 7.x-4.x-silverpop-transact
 
 ; Springboard-sdk-php
 libraries[springboard_sdk_php][directory_name] = springboard_advocacy


### PR DESCRIPTION
@pcave The silverpop transact module requires the addition of the contrib smtp module, which is not on the 4.10-beta1 QA site presently. 